### PR TITLE
Rs kill

### DIFF
--- a/src/commands/rs.ts
+++ b/src/commands/rs.ts
@@ -2,6 +2,7 @@ import { CommandContext } from "@types-local/commands";
 import { SlashCommandBuilder } from "discord.js";
 import { openClue } from "./rs/_clue";
 import { catchAllInteractionReply } from "@utils";
+import { killMonster } from "./rs/_kill";
 
 const rsData = new SlashCommandBuilder()
   .setName("rs")
@@ -37,6 +38,11 @@ const rs = {
         case "open":
           await openClue(ctx);
           break;
+        case "kill":
+          await killMonster(ctx);
+          break;
+        default:
+          throw new Error("Invalid input.");
       }
     } catch (e) {
       console.error(e);

--- a/src/commands/rs.ts
+++ b/src/commands/rs.ts
@@ -1,8 +1,8 @@
 import { CommandContext } from "@types-local/commands";
 import { SlashCommandBuilder } from "discord.js";
-import { openClue } from "./rs/_clue";
+import { openClue } from "./rs/_clue.js";
 import { catchAllInteractionReply } from "@utils";
-import { killMonster } from "./rs/_kill";
+import { killMonster } from "./rs/_kill.js";
 
 const rsData = new SlashCommandBuilder()
   .setName("rs")

--- a/src/commands/rs.ts
+++ b/src/commands/rs.ts
@@ -1,13 +1,7 @@
 import { CommandContext } from "@types-local/commands";
 import { SlashCommandBuilder } from "discord.js";
-import { Clues, Util } from "oldschooljs";
-
-const clueList = [
-  { tier: Clues.Medium, num: 1, name: "Medium" },
-  { tier: Clues.Hard, num: 1, name: "Hard" },
-  { tier: Clues.Elite, num: 1, name: "Elite" },
-  { tier: Clues.Master, num: 1, name: "Master" },
-];
+import { openClue } from "./rs/_clue";
+import { catchAllInteractionReply } from "@utils";
 
 const rsData = new SlashCommandBuilder()
   .setName("rs")
@@ -19,34 +13,35 @@ const rsData = new SlashCommandBuilder()
       .addSubcommand((opt) =>
         opt.setName("open").setDescription("Open a random clue casket!")
       )
+  )
+  .addSubcommand((opt) =>
+    opt
+      .setName("kill")
+      .setDescription("Simulate killing a monster.")
+      .addStringOption((opt) =>
+        opt
+          .setName("monster")
+          .setDescription("Name of the monster to simulate killing.")
+          .setRequired(true)
+      )
   );
 
 const rs = {
   ...rsData.toJSON(),
   async execute(ctx: CommandContext) {
     const { interaction } = ctx;
-    const roll = Math.round(Math.random() * 3);
-    const res = clueList[roll];
-    const rewards = res.tier.open(res.num).items();
-    let total = 0;
+    const cmd = interaction.options.getSubcommand();
 
-    const got = rewards
-      .map((r) => {
-        const item = r[0];
-        const amt = r[1];
-
-        total += item.price * amt;
-        return `${amt}x [${item.name}](<${item.wiki_url}>) (${Util.toKMB(
-          item.price * amt
-        )})`;
-      })
-      .join("\n");
-
-    await interaction.reply(
-      `You opened a **[${
-        res.name
-      }]** clue scroll!\n${got}\n### Total loot: ${Util.toKMB(total)}`
-    );
+    try {
+      switch (cmd) {
+        case "open":
+          await openClue(ctx);
+          break;
+      }
+    } catch (e) {
+      console.error(e);
+      catchAllInteractionReply(interaction, (e as Error).message);
+    }
   },
 };
 

--- a/src/commands/rs/_clue.ts
+++ b/src/commands/rs/_clue.ts
@@ -1,0 +1,23 @@
+import { CommandContext } from "@types-local/commands";
+import { Clues, Util } from "oldschooljs";
+import { parseLoot } from "./_rs_utils";
+
+const clueList = [
+  { tier: Clues.Medium, num: 1, name: "Medium" },
+  { tier: Clues.Hard, num: 1, name: "Hard" },
+  { tier: Clues.Elite, num: 1, name: "Elite" },
+  { tier: Clues.Master, num: 1, name: "Master" },
+];
+
+export async function openClue(ctx: CommandContext) {
+  const { interaction } = ctx;
+  const roll = Math.round(Math.random() * 3);
+  const res = clueList[roll];
+  const rewards = res.tier.open(res.num).items();
+
+  const { got, total } = parseLoot(rewards);
+
+  await interaction.reply(
+    `You opened a **[${res.name}]** clue scroll!\n${got}\n### Total loot: ${total}`
+  );
+}

--- a/src/commands/rs/_clue.ts
+++ b/src/commands/rs/_clue.ts
@@ -1,6 +1,6 @@
 import { CommandContext } from "@types-local/commands";
 import { Clues, Util } from "oldschooljs";
-import { parseLoot } from "./_rs_utils";
+import { parseLoot } from "./_rs_utils.js";
 
 const clueList = [
   { tier: Clues.Medium, num: 1, name: "Medium" },

--- a/src/commands/rs/_kill.ts
+++ b/src/commands/rs/_kill.ts
@@ -1,11 +1,14 @@
 import { CommandContext } from "@types-local/commands";
-import { Monsters, Util } from "oldschooljs";
-import { parseLoot } from "./_rs_utils";
+import { Monsters } from "oldschooljs";
+import { parseLoot } from "./_rs_utils.js";
 
 export async function killMonster(ctx: CommandContext) {
   const { interaction } = ctx;
   const monster = interaction.options.getString("monster") ?? "_____";
-  const found = Monsters.find((m) => m.aliases.includes(monster.toLowerCase()));
+  const found = Monsters.find((m) =>
+    m.aliases.join(" ").includes(monster.toLowerCase())
+  );
+
   if (!found) {
     interaction.reply({
       content: `Monster or alias \`${monster}\` not found.`,
@@ -15,7 +18,7 @@ export async function killMonster(ctx: CommandContext) {
 
   const rewards = found.kill(1, {}).items();
   const { got, total } = parseLoot(rewards);
-  const msg = `You killed [${found.name}](${found.data.wikiURL})!\n${got}\n### Total loot: ${total}`;
+  const msg = `You killed [${found.name}](<${found.data.wikiURL}>)!\n${got}\n### Total loot: ${total}`;
 
   await interaction.reply(msg);
 }

--- a/src/commands/rs/_kill.ts
+++ b/src/commands/rs/_kill.ts
@@ -2,7 +2,7 @@ import { CommandContext } from "@types-local/commands";
 import { Monsters, Util } from "oldschooljs";
 import { parseLoot } from "./_rs_utils";
 
-export async function monsterKill(ctx: CommandContext) {
+export async function killMonster(ctx: CommandContext) {
   const { interaction } = ctx;
   const monster = interaction.options.getString("monster") ?? "_____";
   const found = Monsters.find((m) => m.aliases.includes(monster.toLowerCase()));

--- a/src/commands/rs/_monster.ts
+++ b/src/commands/rs/_monster.ts
@@ -1,0 +1,21 @@
+import { CommandContext } from "@types-local/commands";
+import { Monsters, Util } from "oldschooljs";
+import { parseLoot } from "./_rs_utils";
+
+export async function monsterKill(ctx: CommandContext) {
+  const { interaction } = ctx;
+  const monster = interaction.options.getString("monster") ?? "_____";
+  const found = Monsters.find((m) => m.aliases.includes(monster.toLowerCase()));
+  if (!found) {
+    interaction.reply({
+      content: `Monster or alias \`${monster}\` not found.`,
+    });
+    return;
+  }
+
+  const rewards = found.kill(1, {}).items();
+  const { got, total } = parseLoot(rewards);
+  const msg = `You killed [${found.name}](${found.data.wikiURL})!\n${got}\n### Total loot: ${total}`;
+
+  await interaction.reply(msg);
+}

--- a/src/commands/rs/_rs_utils.ts
+++ b/src/commands/rs/_rs_utils.ts
@@ -1,0 +1,20 @@
+import { Item, Util } from "oldschooljs";
+
+export function parseLoot(rewards: [Item, number][]) {
+  let total = 0;
+
+  const got = rewards
+    .map((r) => {
+      const item = r[0];
+      const amt = r[1];
+
+      total += item.price * amt;
+      return `${amt}x [${item.name}](<${item.wiki_url}>) (${Util.toKMB(
+        item.price * amt
+      )})`;
+    })
+    .join("\n");
+
+  const totalStr = Util.toKMB(total);
+  return { got, total: totalStr };
+}


### PR DESCRIPTION
## Changes
### Features
- Added `/rs kill [monster]`
- The `[monster]` input takes either the full name of a monster or a common alias as defined by `oldschooljs`.
- Refactored the `rs` commands to follow the sub-command directory structure, similar to `vote`.