### PR TITLE
RS: persist user data

### DIFF
--- a/src/commands/rs.ts
+++ b/src/commands/rs.ts
@@ -1,6 +1,6 @@
 import { CommandContext } from "@types-local/commands";
 import { SlashCommandBuilder } from "discord.js";
-import { openClue } from "./rs/_clue.js";
+import { openClue, showClueStats } from "./rs/_clue.js";
 import { catchAllInteractionReply } from "@utils";
 import { killMonster } from "./rs/_kill.js";
 
@@ -13,6 +13,9 @@ const rsData = new SlashCommandBuilder()
       .setDescription("Run clue-related commands.")
       .addSubcommand((opt) =>
         opt.setName("open").setDescription("Open a random clue casket!")
+      )
+      .addSubcommand((opt) =>
+        opt.setName("stats").setDescription("View your clue stats.")
       )
   )
   .addSubcommand((opt) =>
@@ -32,7 +35,7 @@ const rs = {
   async execute(ctx: CommandContext) {
     const { interaction } = ctx;
     const cmd = interaction.options.getSubcommand();
-
+    const cmdGroup = interaction.options.getSubcommandGroup();
     try {
       switch (cmd) {
         case "open":
@@ -40,6 +43,12 @@ const rs = {
           break;
         case "kill":
           await killMonster(ctx);
+          break;
+        case "stats":
+          if (cmdGroup === "clue") {
+            await showClueStats(ctx);
+          }
+
           break;
         default:
           throw new Error("Invalid input.");

--- a/src/commands/rs/_clue.ts
+++ b/src/commands/rs/_clue.ts
@@ -1,5 +1,5 @@
 import { CommandContext } from "@types-local/commands";
-import { Clues, Util } from "oldschooljs";
+import { Clues } from "oldschooljs";
 import { parseLoot } from "./_rs_utils.js";
 
 const clueList = [

--- a/src/commands/rs/_clue.ts
+++ b/src/commands/rs/_clue.ts
@@ -37,6 +37,14 @@ export async function openClue(ctx: CommandContext) {
 export async function showClueStats(ctx: CommandContext) {
   const { interaction, storage } = ctx;
   const userClueData = await storage.getClueData(interaction.user.id);
+  const totalClues = [
+    userClueData.medium,
+    userClueData.hard,
+    userClueData.elite,
+    userClueData.master,
+  ]
+    .map((d) => parseInt(d))
+    .reduce((prev, curr) => prev + curr);
 
   await interaction.reply(
     `### ${interaction.user}'s Clue Stats\n\`\`\`\n${
@@ -44,7 +52,7 @@ export async function showClueStats(ctx: CommandContext) {
     }x Medium\n${userClueData.hard}x Hard\n${userClueData.elite}x Elite\n${
       userClueData.master
     }x Master\`\`\`You've earned **${toKMB(
-      userClueData.clueCoins
-    )}** coins from clues.`
+      parseInt(userClueData.clueCoins)
+    )}** coins from ${totalClues} clue(s).`
   );
 }

--- a/src/commands/rs/_clue.ts
+++ b/src/commands/rs/_clue.ts
@@ -1,6 +1,7 @@
 import { CommandContext } from "@types-local/commands";
 import { Clues } from "oldschooljs";
-import { parseLoot } from "./_rs_utils.js";
+import { getEmptyClueData, parseLoot } from "./_rs_utils.js";
+import { toKMB } from "oldschooljs/dist/util/smallUtils.js";
 
 const clueList = [
   { tier: Clues.Medium, num: 1, name: "Medium" },
@@ -10,14 +11,40 @@ const clueList = [
 ];
 
 export async function openClue(ctx: CommandContext) {
-  const { interaction } = ctx;
+  const { interaction, storage } = ctx;
   const roll = Math.round(Math.random() * 3);
   const res = clueList[roll];
   const rewards = res.tier.open(res.num).items();
 
-  const { got, total } = parseLoot(rewards);
+  const { got, total, totalRaw } = parseLoot(rewards);
+
+  const toUpdate = getEmptyClueData();
+  const clueType = res.name.toLowerCase() as
+    | "medium"
+    | "hard"
+    | "elite"
+    | "master";
+  toUpdate[clueType] = 1;
+  toUpdate.clueCoins = totalRaw;
+
+  await storage.updateClueData(interaction.user.id, toUpdate);
 
   await interaction.reply(
     `You opened a **[${res.name}]** clue scroll!\n${got}\n### Total loot: ${total}`
+  );
+}
+
+export async function showClueStats(ctx: CommandContext) {
+  const { interaction, storage } = ctx;
+  const userClueData = await storage.getClueData(interaction.user.id);
+
+  await interaction.reply(
+    `### ${interaction.user}'s Clue Stats\n\`\`\`\n${
+      userClueData.medium
+    }x Medium\n${userClueData.hard}x Hard\n${userClueData.elite}x Elite\n${
+      userClueData.master
+    }x Master\`\`\`You've earned **${toKMB(
+      userClueData.clueCoins
+    )}** coins from clues.`
   );
 }

--- a/src/commands/rs/_rs_utils.ts
+++ b/src/commands/rs/_rs_utils.ts
@@ -1,33 +1,32 @@
-import { RedisStorage } from "@redis-storage";
 import { Item, Util } from "oldschooljs";
 
-type DBClueData = {
+export type DBClueData = {
   medium: number;
   hard: number;
   elite: number;
   master: number;
-  clue_coins: number;
+  clueCoins: number;
 };
 
-function getEmptyClueData(): DBClueData {
+export function getEmptyClueData(): DBClueData {
   return {
     medium: 0,
     hard: 0,
     elite: 0,
     master: 0,
-    clue_coins: 0,
+    clueCoins: 0,
   } as DBClueData;
 }
 
-function getClueKey(userId: string) {
+export function getClueKey(userId: string) {
   return `users:${userId}:rs:clues`;
 }
 
-function getCoinsKey(userId: string) {
+export function getCoinsKey(userId: string) {
   return `users:${userId}:rs:coins`;
 }
 
-function getKcKey(userId: string, monsterId: number) {
+export function getKcKey(userId: string, monsterId: number) {
   return `user:${userId}:rs:kills:${monsterId}`;
 }
 
@@ -48,27 +47,4 @@ export function parseLoot(rewards: [Item, number][]) {
 
   const totalStr = Util.toKMB(total);
   return { got, total: totalStr, totalRaw: total };
-}
-
-export async function updateClueData(
-  storage: RedisStorage,
-  userId: string,
-  data: DBClueData
-) {
-  const clueKey = getClueKey(userId);
-  await storage.hIncrByFields(clueKey, data);
-}
-
-export async function getClueData(storage: RedisStorage, userId: string) {
-  const clueKey = getClueKey(userId);
-  return await storage.hGetAll(clueKey);
-}
-
-export async function updateCoins(
-  storage: RedisStorage,
-  userId: string,
-  change: number
-) {
-  const coinsKey = getCoinsKey(userId);
-  await storage.set(coinsKey, change.toString());
 }

--- a/src/commands/rs/_rs_utils.ts
+++ b/src/commands/rs/_rs_utils.ts
@@ -1,4 +1,35 @@
+import { RedisStorage } from "@redis-storage";
 import { Item, Util } from "oldschooljs";
+
+type DBClueData = {
+  medium: number;
+  hard: number;
+  elite: number;
+  master: number;
+  clue_coins: number;
+};
+
+function getEmptyClueData(): DBClueData {
+  return {
+    medium: 0,
+    hard: 0,
+    elite: 0,
+    master: 0,
+    clue_coins: 0,
+  } as DBClueData;
+}
+
+function getClueKey(userId: string) {
+  return `users:${userId}:rs:clues`;
+}
+
+function getCoinsKey(userId: string) {
+  return `users:${userId}:rs:coins`;
+}
+
+function getKcKey(userId: string, monsterId: number) {
+  return `user:${userId}:rs:kills:${monsterId}`;
+}
 
 export function parseLoot(rewards: [Item, number][]) {
   let total = 0;
@@ -16,5 +47,28 @@ export function parseLoot(rewards: [Item, number][]) {
     .join("\n");
 
   const totalStr = Util.toKMB(total);
-  return { got, total: totalStr };
+  return { got, total: totalStr, totalRaw: total };
+}
+
+export async function updateClueData(
+  storage: RedisStorage,
+  userId: string,
+  data: DBClueData
+) {
+  const clueKey = getClueKey(userId);
+  await storage.hIncrByFields(clueKey, data);
+}
+
+export async function getClueData(storage: RedisStorage, userId: string) {
+  const clueKey = getClueKey(userId);
+  return await storage.hGetAll(clueKey);
+}
+
+export async function updateCoins(
+  storage: RedisStorage,
+  userId: string,
+  change: number
+) {
+  const coinsKey = getCoinsKey(userId);
+  await storage.set(coinsKey, change.toString());
 }

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -1,5 +1,4 @@
 import { OrNullEntries } from "@types-local/util";
-import { ConfigType } from "@config";
 import { DBClueData } from "@commands/rs/_rs_utils";
 
 const persistedConfigs = ["actionThreshold", "memberRole"] as const;
@@ -53,9 +52,9 @@ export abstract class Storage {
 
   abstract clearMotd(guildId: string): Promise<void>;
 
-  abstract updateClueData(userId: string, data: DBClueData): Promise<void>;
+  abstract updateClueData(userId: string, data: DBClueData<number>): Promise<void>;
 
-  abstract getClueData(userId: string): Promise<DBClueData>;
+  abstract getClueData(userId: string): Promise<DBClueData<string>>;
 
   abstract updateCoins(userId: string, change: number): Promise<void>;
 }

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -1,5 +1,6 @@
 import { OrNullEntries } from "@types-local/util";
 import { ConfigType } from "@config";
+import { DBClueData } from "@commands/rs/_rs_utils";
 
 const persistedConfigs = ["actionThreshold", "memberRole"] as const;
 type PersistedKey = (typeof persistedConfigs)[number];
@@ -51,6 +52,12 @@ export abstract class Storage {
   abstract getMotd(guildId: string): Promise<string | null>;
 
   abstract clearMotd(guildId: string): Promise<void>;
+
+  abstract updateClueData(userId: string, data: DBClueData): Promise<void>;
+
+  abstract getClueData(userId: string): Promise<DBClueData>;
+
+  abstract updateCoins(userId: string, change: number): Promise<void>;
 }
 
 export type { PersistedKey, PersistedConfigs };

--- a/src/types/commands.d.ts
+++ b/src/types/commands.d.ts
@@ -8,8 +8,8 @@ import {
 
 export type CommandContext = {
   interaction: ChatInputCommandInteraction<CacheType>;
-  config?: ConfigType;
-  storage?: Storage;
+  config: ConfigType;
+  storage: Storage;
 };
 
 export type CommandContextRequire<


### PR DESCRIPTION
## Changes
### Features
- Added `/rs clue stats`, which shows your clue stats (obviously).
- Clue stats are now saved in the following form:
```
{
    medium: number,
    hard: number,
    elite: number,
    master: number,
    clueCoins: number,
}
```
- The above operation uses `hIncrBy` with pipelining.
- When clue stats are saved, the user's coin store is also incremented by `clueCoins`.