### PR TITLE
rs: nex and araxxor

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs";
-import path from "node:path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { Command } from "@types-local/commands";
 import { CommandName } from "@/types/generated/commands";
@@ -28,7 +28,9 @@ export async function loadCommands(): Promise<CommandsMap> {
       const cmd: Command = mod[cmdLabel];
 
       if (!cmd) {
-        throw new Error(`File ${f.name} does not contain export "${cmdLabel}".`);
+        throw new Error(
+          `File ${f.name} does not contain export "${cmdLabel}".`
+        );
       }
 
       return [cmdLabel, cmd];

--- a/src/commands/rs/_kill.ts
+++ b/src/commands/rs/_kill.ts
@@ -1,11 +1,15 @@
 import { CommandContext } from "@types-local/commands";
 import { Monsters } from "oldschooljs";
 import { parseLoot } from "./_rs_utils.js";
+import { CustomMonsters } from "./monsters/index.js";
+
+const NativeMonsters = [...Monsters].map((m) => m[1]);
+const NewMonsters = [...NativeMonsters, ...CustomMonsters];
 
 export async function killMonster(ctx: CommandContext) {
   const { interaction } = ctx;
   const monster = interaction.options.getString("monster") ?? "_____";
-  const found = Monsters.find((m) =>
+  const found = NewMonsters.find((m) =>
     m.aliases.join(" ").includes(monster.toLowerCase())
   );
 

--- a/src/commands/rs/_module-remap.ts
+++ b/src/commands/rs/_module-remap.ts
@@ -1,0 +1,7 @@
+import * as SMMod from "oldschooljs/dist/structures/SimpleMonster.js";
+import * as RDTMod from "oldschooljs/dist/simulation/subtables/RareDropTable.js";
+import * as THSTMod from "oldschooljs/dist/simulation/subtables/TreeHerbSeedTable.js";
+
+export const SimpleMonster = (SMMod.default as any).default;
+export const TreeHerbSeedTable = (THSTMod.default as any).default;
+export const RareDropTable = (RDTMod.default as any).default;

--- a/src/commands/rs/_rs_utils.ts
+++ b/src/commands/rs/_rs_utils.ts
@@ -1,4 +1,6 @@
 import { Item, Util } from "oldschooljs";
+import { MonsterData } from "oldschooljs/dist/meta/monsterData";
+import SimpleMonster from "oldschooljs/dist/structures/SimpleMonster";
 
 export type DBClueData<T extends string | number> = {
   medium: T;
@@ -59,4 +61,9 @@ export function parseLoot(rewards: [Item, number][]) {
 
   const totalStr = Util.toKMB(total);
   return { got, total: totalStr, totalRaw: total };
+}
+
+export function attachWikiURL(monster: SimpleMonster, wikiURL: string) {
+  monster.data = {} as MonsterData;
+  monster.data.wikiURL = wikiURL;
 }

--- a/src/commands/rs/monsters/_araxxor.ts
+++ b/src/commands/rs/monsters/_araxxor.ts
@@ -1,0 +1,77 @@
+import { LootTable } from "oldschooljs";
+import {
+  TreeHerbSeedTable,
+  RareDropTable,
+  SimpleMonster,
+} from "../_module-remap.js";
+import { attachWikiURL } from "../_rs_utils.js";
+
+// Taken from https://github.com/oldschoolgg/oldschooljs
+
+const AraxxorUniqueTable = new LootTable()
+  .add("Araxyte fang")
+  .add("Noxious blade")
+  .add("Noxious point")
+  .add("Noxious pommel");
+
+const SupplyDrop = new LootTable()
+  .add(new LootTable().add("Araxyte venom sack").add("Super combat potion(1)"))
+  .add(new LootTable().add("Prayer potion(3)", [1, 2]).add("Prayer potion(4)"))
+  .add(new LootTable().add("Wild pie", [2, 3]).add("Shark", [2, 3]));
+
+const AraxxorTable = new LootTable()
+  .tertiary(50, "Clue scroll (elite)")
+  .tertiary(200, "Coagulated venom")
+  .tertiary(150, AraxxorUniqueTable)
+  .tertiary(250, "Araxyte head")
+  .tertiary(1500, "Jar of venom")
+  .tertiary(3000, "Nid")
+  .oneIn(8, SupplyDrop)
+
+  .add("Rune kiteshield", 2, 8)
+  .add("Rune platelegs", 2, 8)
+  .add("Dragon mace", 2, 6)
+  .add("Rune 2h sword", 5, 1)
+  .add("Dragon platelegs", 2, 1)
+
+  .add("Death rune", 250, 5)
+  .add("Nature rune", 80, 2)
+  .add("Mud rune", 100, 1)
+  .add("Blood rune", 180, 1)
+
+  .add("Yew seed", 1, 4)
+  .add("Toadflax seed", 4, 3)
+  .add("Ranarr seed", 3, 1)
+  .add("Snapdragon seed", 3, 1)
+  .add("Magic seed", 2, 1)
+  .add(TreeHerbSeedTable, 1, 1)
+
+  .add("Coal", 120, 4)
+  .add("Adamantite ore", 85, 4)
+  .add("Raw shark", 21, 4)
+  .add("Yew logs", 70, 3)
+  .add("Runite ore", 12, 2)
+  .add("Raw shark", 100, 1)
+  .add("Raw monkfish", 120, 1)
+  .add("Pure essence", 1200, 1)
+
+  .add("Spider cave teleport", 3, 8)
+  .add("Earth orb", 45, 6)
+  .add("Araxyte venom sack", 6, 5)
+  .add("Mort myre fungus", 24, 4)
+  .add("Antidote++(3)", 6, 4)
+  .add("Wine of zamorak", 8, 3)
+  .add("Red spiders' eggs", 40, 2)
+  .add("Araxyte venom sack", 12, 2)
+  .add("Bark", 15, 1)
+  .add(RareDropTable);
+
+const Araxxor = new SimpleMonster({
+  id: 13668,
+  name: "Araxxor",
+  table: AraxxorTable,
+  aliases: ["araxxor, rax"],
+});
+
+attachWikiURL(Araxxor, "https://oldschool.runescape.wiki/w/Araxxor");
+export { Araxxor };

--- a/src/commands/rs/monsters/_nex.ts
+++ b/src/commands/rs/monsters/_nex.ts
@@ -1,0 +1,66 @@
+import { LootTable } from "oldschooljs";
+import { SimpleMonster } from "../_module-remap.js";
+import { attachWikiURL } from "../_rs_utils.js";
+import { parseLoot } from "../_rs_utils.js";
+
+// Taken from https://github.com/oldschoolgg/oldschooljs
+
+const NexUniqueTable = new LootTable()
+  .add("Zaryte vambraces")
+  .add("Nihil horn")
+  .add("Torva full helm (damaged)")
+  .add("Torva platebody (damaged)")
+  .add("Torva platelegs (damaged)")
+  .add("Ancient hilt");
+
+const NexTable = new LootTable()
+  .tertiary(43, NexUniqueTable)
+  .tertiary(48, "Clue scroll (elite)")
+  .tertiary(500, "Nexling")
+  .tertiary(1, "Big bones")
+
+  .add("Air rune", [123, 1365], 35)
+  .add("Fire rune", [210, 1655], 35)
+  .add("Blood rune", [84, 325], 50)
+  .add("Death rune", [85, 170], 50)
+  .add("Water rune", [193, 1599], 35)
+  .add("Soul rune", [86, 227], 50)
+  .add("Dragon bolts (unf)", [12, 90], 50)
+  .add("Onyx bolts (e)", [11, 29], 35)
+  .add("Cannonball", [42, 298], 50)
+
+  .add("Air orb", [6, 20], 50)
+  .add("Uncut ruby", [3, 26], 50)
+  .add("Uncut diamond", [3, 17], 50)
+  .add("Wine of zamorak", [4, 14], 50)
+  .add("Coal", [23, 95], 35)
+  .add("Runite ore", [2, 30], 35)
+
+  .add(
+    new LootTable().tertiary(1, "Shark", 3).tertiary(1, "Prayer potion(4)", 1),
+    1,
+    50
+  )
+  .add(
+    new LootTable()
+      .tertiary(1, "Saradomin brew(4)", 3)
+      .tertiary(1, "Super restore(4)", 1),
+    1,
+    50
+  )
+
+  .add("Nihil shard", [80, 85], 50)
+  .add("Nihil shard", [85, 95], 31)
+  .add("Coins", [8539, 26748], 35)
+  .add("Blood essence", [1, 2], 10)
+  .add("Rune sword", 1, 4);
+
+const Nex = new SimpleMonster({
+  id: 13447,
+  name: "Nex",
+  table: NexTable,
+  aliases: ["nex"],
+});
+
+attachWikiURL(Nex, "https://oldschool.runescape.wiki/w/Nex");
+export { Nex };

--- a/src/commands/rs/monsters/index.ts
+++ b/src/commands/rs/monsters/index.ts
@@ -1,0 +1,4 @@
+import { Araxxor } from "./_araxxor.js";
+import { Nex } from "./_nex.js";
+
+export const CustomMonsters = [Araxxor, Nex];

--- a/src/handlers/command-handler.ts
+++ b/src/handlers/command-handler.ts
@@ -16,7 +16,7 @@ export async function initCommands(config: ConfigType) {
   const commands = await loadCommands();
   const rest = new REST({ version: "10" }).setToken(config.token);
 
-  console.log(`\nLoaded commands:\n ${JSON.stringify(commands, null, 2)}\n`);
+  console.log(`\nLoaded ${Object.entries(commands).length} commands.\n`);
 
   try {
     console.log("Started refreshing application commands.");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "es2022",
     "moduleResolution": "node",
     "sourceMap": true,
-    "allowSyntheticDefaultImports": true,
     "outDir": "./build",
     "baseUrl": "./src",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "es2022",
     "moduleResolution": "node",
     "sourceMap": true,
+    "allowSyntheticDefaultImports": true,
     "outDir": "./build",
     "baseUrl": "./src",
     "strict": true,


### PR DESCRIPTION
## Changes
### Features
- Added Nex and Araxxor as options for `/rs kill [monster]`.
  - Nex has been configured to follow solo scale drops.
  - The code for Araxxor's table is taken from [oldschoolgg](https://github.com/oldschoolgg/oldschooljs/blob/master/src/simulation/monsters/bosses/Araxxor.ts)'s GitHub page.