### PR TITLE
rs-stake

### DIFF
--- a/src/commands/rs.ts
+++ b/src/commands/rs.ts
@@ -4,7 +4,7 @@ import { openClue, showClueStats } from "./rs/_clue.js";
 import { catchAllInteractionReply } from "@utils";
 import { killMonster } from "./rs/_kill.js";
 import { getInventoryEmbeds, handleBankPages } from "./rs/_bank.js";
-import { stake } from "./rs/_stake.js";
+import { stake, startStake } from "./rs/_stake.js";
 
 const rsData = new SlashCommandBuilder()
   .setName("rs")
@@ -31,10 +31,24 @@ const rsData = new SlashCommandBuilder()
           .setRequired(true)
       )
   )
+  .addSubcommand((opt) => opt.setName("bank").setDescription("View your bank."))
   .addSubcommand((opt) =>
-    opt.setName("bank").setDescription("View your bank.")
+    opt
+      .setName("stake")
+      .setDescription("Simulates a stake between you and another player.")
+      .addUserOption((opt) =>
+        opt
+          .setName("opponent")
+          .setDescription("Person to challenge as your opponent.")
+          .setRequired(true)
+      )
+      .addStringOption((opt) =>
+        opt
+          .setName("stake")
+          .setDescription("Amount of gold to stake")
+          .setRequired(false)
+      )
   );
-
 
 const rs = {
   ...rsData.toJSON(),
@@ -67,6 +81,9 @@ const rs = {
           });
 
           await handleBankPages(ctx, msg, out);
+          break;
+        case "stake":
+          await startStake(ctx);
           break;
         default:
           throw new Error("Invalid input.");

--- a/src/commands/rs/_stake.ts
+++ b/src/commands/rs/_stake.ts
@@ -78,12 +78,28 @@ export async function stake(p1: User, p2: User, coins?: number) {
 }
 
 export async function sendStakeInvite(
-  ctx: Command,
+  ctx: CommandContext,
   p1: User,
   p2: User,
-  coins: string
+  coins: number
 ) {
   const { interaction } = ctx;
+  const channel = interaction.channel;
+
+  const announceDesc = `${p1} has challenged ${p2} to a stake${
+    coins > 0 ? ` for ${Util.toKMB(coins)} coins!` : `!`
+  }`;
+
+  if (channel?.isSendable()) {
+    await channel.send({
+      embeds: [
+        new EmbedBuilder()
+          .setColor("DarkRed")
+          .setTitle("Stake Challenge")
+          .setDescription(announceDesc),
+      ],
+    });
+  }
 }
 
 export async function confirmStake(
@@ -146,7 +162,15 @@ export async function confirmStake(
           components: [],
         });
       } else if (i.customId === "yes") {
-        // send invite here
+        await sendStakeInvite(ctx, p1, p2, coinsValue);
+        await i.update({
+          embeds: [
+            new EmbedBuilder()
+              .setColor("DarkRed")
+              .setDescription(`Stake request sent.`),
+          ],
+          components: [],
+        });
       }
 
       collector.stop();
@@ -163,6 +187,8 @@ export async function confirmStake(
           components: [],
         });
     });
+  } else {
+    await sendStakeInvite(ctx, p1, p2, 0);
   }
 }
 

--- a/src/commands/rs/_stake.ts
+++ b/src/commands/rs/_stake.ts
@@ -208,6 +208,7 @@ export async function sendStakeInvite(
                     )} coins from ${loser}'s bank and gave it to ${winner}.`
                   ),
               ],
+              allowedMentions: { parse: ["users"] },
             });
           }
         }

--- a/src/commands/rs/_stake.ts
+++ b/src/commands/rs/_stake.ts
@@ -1,0 +1,78 @@
+import { Command, CommandContext } from "@types-local/commands";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ComponentType,
+  EmbedBuilder,
+  MessageFlags,
+  User,
+} from "discord.js";
+import { Util } from "oldschooljs";
+import { fromKMB } from "oldschooljs/dist/util";
+
+type StyleBonuses = {
+  attack: number;
+  strength: number;
+  defence: number;
+};
+
+export async function stake(p1: User, p2: User, coins?: number) {
+  const styleBonuses: StyleBonuses = {
+    attack: 0,
+    strength: 3,
+    defence: 0,
+  };
+
+  const wepStrBonus = 89;
+  const prayStrMult = 1;
+  const strLvl = 99;
+  const strBoost = 0;
+
+  const wepAtkBonus = 89;
+  const prayAtkMult = 1;
+  const atkLvl = 99;
+  const atkBoost = 0;
+
+  const defLvl = 99;
+  const defBonus = 0;
+  const defBoost = 0;
+  const prayDefMult = 1;
+
+  const effStr =
+    Math.floor((strLvl + strBoost) * prayStrMult) + styleBonuses.strength + 8;
+  const maxHit = Math.floor((effStr * (wepStrBonus + 64) + 320) / 640);
+
+  const effAtk =
+    Math.floor((atkLvl + atkBoost) * prayAtkMult) + styleBonuses.attack;
+  const atkRoll = Math.floor(effAtk * (wepAtkBonus + 64));
+
+  const effDef =
+    Math.floor((defLvl + defBoost) * prayDefMult) + styleBonuses.defence + 8;
+
+  const defRoll = effDef * (defBonus + 64);
+
+  let hitChance = 0;
+  if (atkRoll > defRoll) {
+    hitChance = 1 - (defRoll + 2) / (2 * (atkRoll + 1));
+  } else {
+    hitChance = atkRoll / (2 * (defRoll + 1));
+  }
+
+  // Person who initiated the command is p1
+  const players = [99, 99];
+  const users = [p1, p2];
+  const logs = [];
+  let ptr = Math.round(Math.random());
+  while (players[0] > 0 && players[1] > 0) {
+    const roll = Math.random();
+    let dmg = 0;
+    if (roll >= hitChance) {
+      dmg = Math.round(Math.random() * maxHit) ?? 1;
+    }
+
+    players[ptr] -= dmg;
+    logs.push(`${users[ptr]} hit ${users[(ptr + 1) % 2]} for ${dmg} damage!`);
+    ptr = (ptr + 1) % 2;
+  }
+}


### PR DESCRIPTION
## Changes
### Features
- Implemented `/rs stake [user] (stake)`, which is a simulated whip-stake with an optional stake amount.
- Stakes with an actual stake amount will prompt a confirmation message upon sending.
- All interaction replies expire in 15 seconds.
- Upon the conclusion of a stake, if any stake amount was set, the loser loses that amount and the winner gains it.
- The input to `(stake)` can either be an integer or a number in `KMB` (see `oldschooljs`) format.