### PR TITLE
rs-transfer

### DIFF
--- a/src/commands/rs.ts
+++ b/src/commands/rs.ts
@@ -6,6 +6,7 @@ import { killMonster } from "./rs/_kill.js";
 import { getInventoryEmbeds, handleBankPages } from "./rs/_bank.js";
 import { stake, startStake } from "./rs/_stake.js";
 import { checkBalance } from "./rs/_balance.js";
+import { transferCoins } from "./rs/_transfer.js";
 
 const rsData = new SlashCommandBuilder()
   .setName("rs")
@@ -52,6 +53,23 @@ const rsData = new SlashCommandBuilder()
   )
   .addSubcommand((opt) =>
     opt.setName("balance").setDescription("Check your coin balance.")
+  )
+  .addSubcommand((opt) =>
+    opt
+      .setName("transfer")
+      .setDescription("Transfer coins to another user.")
+      .addUserOption((opt) =>
+        opt
+          .setName("recipient")
+          .setDescription("User to transfer coins to.")
+          .setRequired(true)
+      )
+      .addStringOption((opt) =>
+        opt
+          .setName("amount")
+          .setDescription("Amount of coins to transfer.")
+          .setRequired(true)
+      )
   );
 
 const rs = {
@@ -91,6 +109,22 @@ const rs = {
           break;
         case "balance":
           await checkBalance(ctx);
+          break;
+        case "transfer":
+          const p1 = interaction.user;
+          const p2 = interaction.options.getUser("recipient");
+          const amount = interaction.options.getString("amount");
+
+          if (!p2)
+            return await interaction.reply(
+              "You must indicate a recipient to transfer coins to."
+            );
+          if (!amount)
+            return await interaction.reply(
+              "You must indicate an amount to transfer."
+            );
+
+          await transferCoins(ctx, p1, p2, amount);
           break;
         default:
           throw new Error("Invalid input.");

--- a/src/commands/rs/_transfer.ts
+++ b/src/commands/rs/_transfer.ts
@@ -102,13 +102,14 @@ export async function transferCoins(
 
     collector.on("end", async (_, reason) => {
       if (reason === "time") {
-        await interaction.reply({
+        await interaction.editReply({
           embeds: [
             new EmbedBuilder()
+              .setTitle(`Transfer to ${p2.displayName}`)
               .setColor("DarkRed")
               .setDescription(`Transfer expired.`),
           ],
-          flags: [MessageFlags.Ephemeral],
+          components: [],
         });
       }
     });

--- a/src/commands/rs/_transfer.ts
+++ b/src/commands/rs/_transfer.ts
@@ -1,0 +1,116 @@
+import { CommandContext } from "@types-local/commands";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  CacheType,
+  ComponentType,
+  EmbedBuilder,
+  MessageFlags,
+  User,
+} from "discord.js";
+import { Util } from "oldschooljs";
+
+async function executeTransfer(
+  ctx: CommandContext,
+  p1: User,
+  p2: User,
+  value: number,
+  i: ButtonInteraction<CacheType>
+) {
+  const { storage } = ctx;
+  const amountKmb = Util.toKMB(value);
+  await storage.updateCoins(p1.id, value * -1);
+  await storage.updateCoins(p2.id, value);
+
+  await i.update({
+    embeds: [
+      new EmbedBuilder()
+        .setTitle(`Transfer to ${p2.displayName}`)
+        .setColor("DarkGreen")
+        .setDescription(
+          `${p1} has successfully transferred ${value.toLocaleString()} coins to ${p2}.`
+        ),
+    ],
+    components: [],
+  });
+}
+
+export async function transferCoins(
+  ctx: CommandContext,
+  p1: User,
+  p2: User,
+  amountKmb: string
+) {
+  const { interaction, storage } = ctx;
+  const value = Util.fromKMB(amountKmb);
+
+  const owned = await storage.getCoins(p1.id);
+  if (owned < value || Number.isNaN(value) || !value) {
+    return await interaction.reply({
+      content: "You do not have enough coins for this transfer.",
+      flags: [MessageFlags.Ephemeral],
+    });
+  } else {
+    const msg = await interaction.reply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle(`Transfer to ${p2.displayName}`)
+          .setColor("DarkRed")
+          .setDescription(
+            `Are you sure you want to transfer ${value.toLocaleString()} coins to ${p2}?`
+          ),
+      ],
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().setComponents(
+          new ButtonBuilder()
+            .setCustomId("yes")
+            .setLabel("Yes")
+            .setStyle(ButtonStyle.Success),
+          new ButtonBuilder()
+            .setCustomId("no")
+            .setLabel("No")
+            .setStyle(ButtonStyle.Danger)
+        ),
+      ],
+    });
+
+    const collector = msg.createMessageComponentCollector({
+      filter: (i) => i.user.id === p1.id,
+      time: 15000,
+      componentType: ComponentType.Button,
+    });
+
+    collector.on("collect", async (i) => {
+      if (i.customId === "yes") {
+        await executeTransfer(ctx, p1, p2, value, i);
+      } else {
+        await i.update({
+          embeds: [
+            new EmbedBuilder()
+              .setTitle(`Transfer to ${p2.displayName}`)
+              .setColor("DarkRed")
+              .setDescription(`Transfer cancelled.`),
+          ],
+          components: [],
+        });
+      }
+
+      collector.stop();
+    });
+
+    collector.on("end", async (_, reason) => {
+      if (reason === "time") {
+        await interaction.reply({
+          embeds: [
+            new EmbedBuilder()
+              .setColor("DarkRed")
+              .setDescription(`Transfer expired.`),
+          ],
+          flags: [MessageFlags.Ephemeral],
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Changes
### Features
- Implemented `/rs transfer [user] [amount]`, which allows a user to transfer coins to another user.
- Upon running the command, a confirmation prompt is posted by the bot.
- The confirmation prompt expires in 15 seconds.
- The bot checks if the user has enough coins beforehand.