### PR TITLE
/kill teams

### DIFF
--- a/src/commands/rs/_kill.ts
+++ b/src/commands/rs/_kill.ts
@@ -1,10 +1,68 @@
 import { CommandContext } from "@types-local/commands";
-import { Monsters } from "oldschooljs";
+import { Monster, Monsters } from "oldschooljs";
 import { parseLoot } from "./_rs_utils.js";
 import { CustomMonsters } from "./monsters/index.js";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  InteractionCallback,
+  User,
+} from "discord.js";
 
 const NativeMonsters = [...Monsters].map((m) => m[1]);
 const NewMonsters = [...NativeMonsters, ...CustomMonsters];
+
+type MonsterMetaData = {
+  [monsterId: number]: {
+    teamBoss: boolean;
+    partySizes: number[];
+    cooldowns: number[];
+  };
+};
+
+const metadata: MonsterMetaData = {
+  13447: {
+    teamBoss: true,
+    partySizes: [1, 2, 3, 4, 5],
+    cooldowns: [7200, 1800, 1200, 900, 600],
+  },
+};
+
+async function killTeamMonster(ctx: CommandContext, monster: Monster) {
+  const { interaction, storage } = ctx;
+  const { partySizes, cooldowns } = metadata[monster.id];
+  const cdList = partySizes
+    .map((e, i) => `${e}: ${cooldowns[i] / 60} minutes`)
+    .join("\n");
+
+  const partyMems: User[] = [];
+  const msg = await interaction.reply({
+    embeds: [
+      new EmbedBuilder()
+        .setColor("Aqua")
+        .setTitle(`${monster.name}: ${interaction.user.displayName}'s party`)
+        .setDescription(
+          `You have opted to kill a team boss.\nThis boss can be killed in parties of: ${partySizes}.\n\nThe following are the cooldowns incurred by each party size:\n${cdList}\n\n**Members**\n- ${interaction.user} (leader)`
+        ),
+    ],
+    components: [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId("join")
+          .setLabel("Join")
+          .setStyle(ButtonStyle.Success),
+        ...partyMems.map((p) =>
+          new ButtonBuilder()
+            .setCustomId(p.id)
+            .setLabel(`Remove ${p}`)
+            .setStyle(ButtonStyle.Danger)
+        )
+      ),
+    ],
+  });
+}
 
 export async function killMonster(ctx: CommandContext) {
   const { interaction } = ctx;
@@ -20,9 +78,18 @@ export async function killMonster(ctx: CommandContext) {
     return;
   }
 
-  const rewards = found.kill(1, {}).items();
-  const { got, total } = parseLoot(rewards);
-  const msg = `You killed [${found.name}](<${found.data.wikiURL}>)!\n${got}\n### Total loot: ${total}`;
+  if (found.id in metadata) {
+    const { teamBoss, cooldowns } = metadata[found.id];
+    if (teamBoss) {
+      await killTeamMonster(ctx, found);
+    } else if (cooldowns.length > 0) {
+      // set cooldown to cooldowns[0]
+    }
+  } else {
+    const rewards = found.kill(1, {}).items();
+    const { got, total } = parseLoot(rewards);
+    const msg = `You killed [${found.name}](<${found.data.wikiURL}>)!\n${got}\n### Total loot: ${total}`;
 
-  await interaction.reply(msg);
+    await interaction.reply(msg);
+  }
 }

--- a/src/commands/rs/_kill.ts
+++ b/src/commands/rs/_kill.ts
@@ -105,13 +105,13 @@ async function killTeamMonster(ctx: CommandContext, monster: Monster) {
 
   const collector = msg.createMessageComponentCollector({
     filter: (i) => !i.user.bot,
-    time: 5000,
+    time: 60000,
     componentType: ComponentType.Button,
   });
 
   collector.on("end", async (_, reason) => {
     if (reason === "time") {
-      interaction.editReply({
+      await interaction.editReply({
         embeds: [
           new EmbedBuilder()
             .setTitle(
@@ -120,10 +120,11 @@ async function killTeamMonster(ctx: CommandContext, monster: Monster) {
             .setColor("DarkRed")
             .setDescription("Party expired."),
         ],
+        components: [],
       });
     }
 
-    storage.delInMemory(`$`);
+    storage.delInMemory(getInMemoryPartyKey(interaction.user.id));
   });
 
   collector.on("collect", async (i) => {

--- a/src/commands/rs/_kill.ts
+++ b/src/commands/rs/_kill.ts
@@ -23,6 +23,7 @@ type MonsterMetaData = {
   };
 };
 
+// partySizes and cooldowns must have the same length
 const metadata: MonsterMetaData = {
   13447: {
     teamBoss: true,
@@ -68,7 +69,11 @@ function renderActiveParty(
         new ButtonBuilder()
           .setCustomId("disband")
           .setLabel("Disband")
-          .setStyle(ButtonStyle.Secondary)
+          .setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder()
+          .setCustomId("start")
+          .setLabel("Start")
+          .setStyle(ButtonStyle.Primary)
       ),
     ],
   };
@@ -120,6 +125,26 @@ async function killTeamMonster(ctx: CommandContext, monster: Monster) {
         components: [],
       });
       return collector.stop();
+    } else if (i.customId === "start") {
+      const rewards = monster.kill(1, {}).items();
+      const { got, total, totalRaw } = parseLoot(rewards);
+      const memIds = partyMems.map((pm) => pm.id);
+      const memList = partyMems.map((pm) => `- ${pm}`).join("\n");
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setColor("Green")
+            .setTitle(`Nex: ${interaction.user.displayName}'s party (success)`)
+            .setDescription(
+              `Success! You killed Nex for:\n${got}\n\n${
+                partyMems.length > 0
+                  ? `Rewards have been sold and split equally amongst party members:\n${memList}`
+                  : `You killed ${monster.name} alone, so you reaped all the rewards!`
+              }`
+            ),
+        ],
+        components: [],
+      });
     } else {
       if (i.user.id !== interaction.user.id) {
         return await i.reply({

--- a/src/storage/RedisStorage.ts
+++ b/src/storage/RedisStorage.ts
@@ -47,9 +47,22 @@ function decodeValueFromKey(
 
 export class RedisStorage implements Storage {
   private _client: ReturnType<typeof createClient>;
+  private _inMemory: { [key: string]: string | null } = {};
 
   private constructor(client: typeof this._client) {
     this._client = client;
+  }
+
+  public getInMemory(key: string): string | null {
+    return this._inMemory[key] ?? null;
+  }
+
+  public setInMemory(key: string, value: string) {
+    this._inMemory[key] = value;
+  }
+
+  public delInMemory(key: string) {
+    this._inMemory[key] = null;
   }
 
   public static async create(config: ConfigType) {

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -66,6 +66,14 @@ export abstract class Storage {
 
   abstract getInventory(userId: string): Promise<{ [id: string]: string }>;
 
+  abstract setKillCd(
+    userId: string,
+    monsterId: number,
+    cdSecs: number
+  ): Promise<void>;
+
+  abstract checkKillCd(userId: string, monsterId: number): Promise<number>;
+
   abstract updateInventory(
     userId: string,
     items: [Item, number][]

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -17,6 +17,10 @@ type RetrievedGatekept = {
   channelId: string;
 };
 export abstract class Storage {
+  abstract getInMemory(key: string): string | null;
+  abstract setInMemory(key: string, value: string): void;
+  abstract delInMemory(key: string): void;
+
   abstract registerConfig<T extends PersistedKey>(
     guildId: string,
     config: {


### PR DESCRIPTION
## Changes
### Features
- Implemented teams for certain monsters in `/rs kill [monster]`.
- Implemented cooldowns for certain monsters.
  - Added 5 different cooldowns for 5 different party sizes for Nex.
  - Party sizes: `1, 2, 3, 4, 5`
  - Cooldowns: `2 hours, 30 minutes, 20 minutes, 15 minutes, 10 minutes`
    - Cooldowns roughly reflect the "difficulty" of the boss in the game (alongside a few other balancing factors such as drop rate).
- This will prompt a party recruitment board through which other users can join.
  - The board will expire after 60 seconds.
  - The board has `start` `disband` and `remove [member]` buttons which only the party leader can press.
  - Sessions for the recruitment board are tracked; users may only have one party open at a time.
    - However, users may be **in** multiple parties at a time.
- You are unable to join parties whose boss you are on cooldown for.
- Parties that have members who are on cooldown for the boss cannot be started until they are removed (including the party leader, in which case the party must be disbanded).
- Rewards from team kills are currently auto-sold and are split equally among all members.