### PR TITLE
Refactor confirmation

### DIFF
--- a/src/commands/lib/_cmd-utils.ts
+++ b/src/commands/lib/_cmd-utils.ts
@@ -1,0 +1,139 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonComponent,
+  ButtonInteraction,
+  ButtonStyle,
+  CacheType,
+  ChatInputCommandInteraction,
+  ComponentType,
+  EmbedBuilder,
+  InteractionCallbackResponse,
+  InteractionReplyOptions,
+  Message,
+  MessageFlags,
+} from "discord.js";
+
+type ConfirmationDialogOpts = {
+  confirmButtonLabel?: string;
+  cancelButtonLabel?: string;
+  prompt?: string;
+  title?: string;
+  ephemeral?: boolean;
+  expiryMs?: number;
+};
+
+type ConfirmationDialogHandlers = {
+  handleConfirm?: (i: ButtonInteraction<CacheType>) => Promise<any>;
+  handleCancel?: (i: ButtonInteraction<CacheType>) => Promise<any>;
+  handleExpiry?: () => Promise<any>;
+};
+
+export async function promptConfirmationDialog(
+  interaction: ChatInputCommandInteraction<CacheType>,
+  {
+    handleConfirm,
+    handleCancel,
+    handleExpiry,
+  }: ConfirmationDialogHandlers = {},
+  {
+    confirmButtonLabel = "Confirm",
+    cancelButtonLabel = "Cancel",
+    prompt = "Are you sure you wish to do this?",
+    title = "Confirmation",
+    ephemeral = true,
+    expiryMs = 15000,
+  }: ConfirmationDialogOpts = {}
+) {
+  if (!handleConfirm)
+    handleConfirm = async (i) =>
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle(title)
+            .setDescription("Success!")
+            .setColor("DarkGreen"),
+        ],
+        components: [],
+      });
+
+  if (!handleCancel)
+    handleCancel = async (i) =>
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle(title)
+            .setDescription("Cancelled.")
+            .setColor("DarkRed"),
+        ],
+        components: [],
+      });
+
+  if (!handleExpiry)
+    handleExpiry = async () => {
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle(title)
+            .setDescription("Confirmation expired.")
+            .setColor("DarkRed"),
+        ],
+        components: [],
+      });
+    };
+
+  const content: InteractionReplyOptions & { withResponse: true } = {
+    embeds: [
+      new EmbedBuilder()
+        .setTitle(title)
+        .setDescription(prompt)
+        .setColor("DarkRed"),
+    ],
+    components: [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId("confirm")
+          .setLabel(confirmButtonLabel)
+          .setStyle(ButtonStyle.Danger),
+        new ButtonBuilder()
+          .setCustomId("cancel")
+          .setLabel(cancelButtonLabel)
+          .setStyle(ButtonStyle.Secondary)
+      ),
+    ],
+    flags: [],
+    withResponse: true,
+  };
+
+  if (ephemeral) content.flags = MessageFlags.Ephemeral;
+  const res: InteractionCallbackResponse = await interaction.reply(content);
+  const msg = res.resource?.message;
+  if (!msg) throw new Error("Can't find response msg.");
+
+  const collector = msg.createMessageComponentCollector({
+    filter: (i) => i.user.id === interaction.user.id,
+    time: expiryMs,
+    componentType: ComponentType.Button,
+  });
+
+  collector.on("collect", async (i) => {
+    if (i.customId === "confirm") {
+      await handleConfirm(i);
+    } else {
+      await handleCancel(i);
+    }
+
+    collector.stop();
+  });
+
+  collector.on("end", async (_, reason) => {
+    if (reason === "time") {
+      await handleExpiry();
+    }
+  });
+
+  if (!ephemeral)
+    collector.on("ignore", async (i) => {
+      await i.reply("Only the sender of an interaction can confirm it!");
+    });
+}

--- a/src/commands/lib/_cmd-utils.ts
+++ b/src/commands/lib/_cmd-utils.ts
@@ -26,6 +26,7 @@ type ConfirmationDialogOpts = {
 type ConfirmationDialogHandlers = {
   handleConfirm?: (i: ButtonInteraction<CacheType>) => Promise<any>;
   handleCancel?: (i: ButtonInteraction<CacheType>) => Promise<any>;
+  handleIgnore?: (i: ButtonInteraction<CacheType>) => Promise<any>;
   handleExpiry?: () => Promise<any>;
 };
 
@@ -34,6 +35,7 @@ export async function promptConfirmationDialog(
   {
     handleConfirm,
     handleCancel,
+    handleIgnore,
     handleExpiry,
   }: ConfirmationDialogHandlers = {},
   {
@@ -67,6 +69,13 @@ export async function promptConfirmationDialog(
             .setColor("DarkRed"),
         ],
         components: [],
+      });
+
+  if (!handleIgnore)
+    handleIgnore = async (i) =>
+      await i.reply({
+        content: "Only the sender of an interaction can confirm it!",
+        flags: [MessageFlags.Ephemeral],
       });
 
   if (!handleExpiry)
@@ -134,6 +143,6 @@ export async function promptConfirmationDialog(
 
   if (!ephemeral)
     collector.on("ignore", async (i) => {
-      await i.reply("Only the sender of an interaction can confirm it!");
+      await handleIgnore(i);
     });
 }

--- a/src/commands/lib/_cmd-utils.ts
+++ b/src/commands/lib/_cmd-utils.ts
@@ -30,22 +30,19 @@ type ConfirmationDialogHandlers = {
 
 export async function promptConfirmationDialog(
   interaction: ChatInputCommandInteraction<CacheType>,
-  {
-    handleConfirm,
-    handleCancel,
-    handleIgnore,
-    handleExpiry,
-  }: ConfirmationDialogHandlers = {},
-  {
+  handlers: ConfirmationDialogHandlers = {},
+  opts: ConfirmationDialogOpts = {}
+) {
+  const {
     confirmButtonLabel = "Confirm",
     cancelButtonLabel = "Cancel",
     prompt = "Are you sure you wish to do this?",
     title = "Confirmation",
     ephemeral = true,
     expiryMs = 15000,
-  }: ConfirmationDialogOpts = {}
-) {
-  if (!handleConfirm)
+  } = opts;
+
+  const {
     handleConfirm = async (i) =>
       await i.update({
         embeds: [
@@ -55,9 +52,7 @@ export async function promptConfirmationDialog(
             .setColor("DarkGreen"),
         ],
         components: [],
-      });
-
-  if (!handleCancel)
+      }),
     handleCancel = async (i) =>
       await i.update({
         embeds: [
@@ -67,16 +62,12 @@ export async function promptConfirmationDialog(
             .setColor("DarkRed"),
         ],
         components: [],
-      });
-
-  if (!handleIgnore)
+      }),
     handleIgnore = async (i) =>
       await i.reply({
         content: "Only the sender of an interaction can confirm it!",
         flags: [MessageFlags.Ephemeral],
-      });
-
-  if (!handleExpiry)
+      }),
     handleExpiry = async () => {
       await interaction.editReply({
         embeds: [
@@ -87,7 +78,8 @@ export async function promptConfirmationDialog(
         ],
         components: [],
       });
-    };
+    },
+  } = handlers;
 
   const content: InteractionReplyOptions & { withResponse: true } = {
     embeds: [

--- a/src/commands/lib/_cmd-utils.ts
+++ b/src/commands/lib/_cmd-utils.ts
@@ -1,7 +1,6 @@
 import {
   ActionRowBuilder,
   ButtonBuilder,
-  ButtonComponent,
   ButtonInteraction,
   ButtonStyle,
   CacheType,
@@ -10,7 +9,6 @@ import {
   EmbedBuilder,
   InteractionCallbackResponse,
   InteractionReplyOptions,
-  Message,
   MessageFlags,
 } from "discord.js";
 

--- a/src/commands/rs/_bank.ts
+++ b/src/commands/rs/_bank.ts
@@ -1,4 +1,4 @@
-import { promptConfirmationDialog } from "@commands/lib/_cmd-utils";
+import { promptConfirmationDialog } from "../lib/_cmd-utils.js";
 import { CommandContext } from "@types-local/commands";
 import {
   ActionRowBuilder,

--- a/src/commands/rs/_sell.ts
+++ b/src/commands/rs/_sell.ts
@@ -1,4 +1,4 @@
-import { promptConfirmationDialog } from "@commands/lib/_cmd-utils";
+import { promptConfirmationDialog } from "../lib/_cmd-utils.js";
 import { CommandContext } from "@types-local/commands";
 import { ButtonInteraction, EmbedBuilder, MessageFlags } from "discord.js";
 import { Items } from "oldschooljs";

--- a/src/commands/rs/_sell.ts
+++ b/src/commands/rs/_sell.ts
@@ -1,99 +1,7 @@
+import { promptConfirmationDialog } from "@commands/lib/_cmd-utils";
 import { CommandContext } from "@types-local/commands";
-import {
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonInteraction,
-  ButtonStyle,
-  CacheType,
-  ComponentType,
-  EmbedBuilder,
-  InteractionCollector,
-  MessageFlags,
-} from "discord.js";
-import { Item, Items } from "oldschooljs";
-
-type HandlerContext = {
-  collector: InteractionCollector<ButtonInteraction<CacheType>>;
-  i: ButtonInteraction<CacheType>;
-} & CommandContext;
-
-async function handleEnd(ctx: CommandContext, reason: string) {
-  const { interaction } = ctx;
-  if (reason === "time") {
-    try {
-      return await interaction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setDescription("Sell request expired.")
-            .setColor("DarkRed"),
-        ],
-        components: [],
-      });
-    } catch (e) {
-      console.error(e);
-    }
-  }
-}
-
-async function handleCollect(
-  ctx: HandlerContext,
-  item: Item,
-  quantity: number
-) {
-  const { collector, i, interaction, storage } = ctx;
-  try {
-    if (i.customId === "sell") {
-      const value = item.price * quantity;
-      await storage.updateInventory(interaction.user.id, [[item, -quantity]]);
-      await storage.updateCoins(interaction.user.id, value);
-      await i.update({
-        embeds: [
-          new EmbedBuilder()
-            .setDescription("Sell request sent.")
-            .setColor("DarkGreen"),
-        ],
-        components: [],
-      });
-
-      const channel = i.channel;
-      const content = {
-        embeds: [
-          new EmbedBuilder()
-            .setAuthor({
-              name: interaction.user.displayName,
-              iconURL: interaction.user.avatarURL() ?? "",
-            })
-            .setTitle(`Sold: ${quantity}x ${item.name}`)
-            .setDescription(
-              `${interaction.user.displayName} sold \`${quantity}x ${
-                item.name
-              }\` for \`${value.toLocaleString()}\` coins.`
-            )
-            .setColor("DarkGold"),
-        ],
-        components: [],
-      };
-      if (channel?.isSendable()) {
-        await channel.send(content);
-      } else {
-        await i.followUp(content);
-      }
-    } else {
-      await i.update({
-        embeds: [
-          new EmbedBuilder()
-            .setDescription("Cancelled sell request.")
-            .setColor("DarkRed"),
-        ],
-        components: [],
-      });
-    }
-  } catch (e) {
-    console.error(e);
-  }
-
-  collector.stop();
-}
+import { ButtonInteraction, EmbedBuilder, MessageFlags } from "discord.js";
+import { Items } from "oldschooljs";
 
 export async function sellItems(ctx: CommandContext) {
   const { interaction, storage } = ctx;
@@ -145,42 +53,78 @@ export async function sellItems(ctx: CommandContext) {
 
   const itemNum = userInv[item.id.toString()];
   if (quantity <= parseInt(itemNum)) {
-    const msg = await interaction.reply({
-      embeds: [
-        new EmbedBuilder()
-          .setTitle(`Selling: ${quantity}x ${item.name}`)
-          .setDescription(
-            `Are you sure you wish to sell \`${quantity}x ${item.name}\`?`
-          )
-          .setColor("DarkRed"),
-      ],
-      components: [
-        new ActionRowBuilder<ButtonBuilder>().addComponents(
-          new ButtonBuilder()
-            .setCustomId("sell")
-            .setLabel("Sell")
-            .setStyle(ButtonStyle.Danger),
-          new ButtonBuilder()
-            .setCustomId("cancel")
-            .setLabel("Cancel")
-            .setStyle(ButtonStyle.Secondary)
-        ),
-      ],
-      flags: [MessageFlags.Ephemeral],
-      withResponse: true,
-    });
+    const handleConfirm = async (i: ButtonInteraction) => {
+      const value = item.price * quantity;
+      await storage.updateInventory(interaction.user.id, [[item, -quantity]]);
+      await storage.updateCoins(interaction.user.id, value);
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setDescription("Sell request sent.")
+            .setColor("DarkGreen"),
+        ],
+        components: [],
+      });
 
-    const collector = msg.resource?.message?.createMessageComponentCollector({
-      filter: (i) => i.user.id === interaction.user.id,
-      time: 15000,
-      componentType: ComponentType.Button,
-    });
+      const channel = i.channel;
+      const content = {
+        embeds: [
+          new EmbedBuilder()
+            .setAuthor({
+              name: interaction.user.displayName,
+              iconURL: interaction.user.avatarURL() ?? "",
+            })
+            .setTitle(`Sold: ${quantity}x ${item.name}`)
+            .setDescription(
+              `${interaction.user.displayName} sold \`${quantity}x ${
+                item.name
+              }\` for \`${value.toLocaleString()}\` coins.`
+            )
+            .setColor("DarkGold"),
+        ],
+        components: [],
+      };
+      if (channel?.isSendable()) {
+        await channel.send(content);
+      } else {
+        await i.followUp(content);
+      }
+    };
 
-    collector?.on("collect", (i) =>
-      handleCollect({ collector, i, ...ctx }, item, quantity)
+    const handleCancel = async (i: ButtonInteraction) =>
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setDescription("Cancelled sell request.")
+            .setColor("DarkRed"),
+        ],
+        components: [],
+      });
+
+    const handleExpiry = async () =>
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setDescription("Sell request expired.")
+            .setColor("DarkRed"),
+        ],
+        components: [],
+      });
+
+    await promptConfirmationDialog(
+      interaction,
+      {
+        handleConfirm,
+        handleCancel,
+        handleExpiry,
+      },
+      {
+        confirmButtonLabel: "Sell",
+        cancelButtonLabel: "Cancel",
+        title: `Selling: ${quantity}x ${item.name}`,
+        prompt: `Are you sure you wish to sell \`${quantity}x ${item.name}\`?`,
+      }
     );
-
-    collector?.on("end", async (_, reason) => handleEnd(ctx, reason));
   } else {
     const responseMsg =
       parseInt(itemNum) > 0

--- a/src/commands/rs/_stake.ts
+++ b/src/commands/rs/_stake.ts
@@ -1,4 +1,4 @@
-import { promptConfirmationDialog } from "@commands/lib/_cmd-utils";
+import { promptConfirmationDialog } from "../lib/_cmd-utils.js";
 import { CommandContext } from "@types-local/commands";
 import {
   ActionRowBuilder,

--- a/src/commands/rs/_stake.ts
+++ b/src/commands/rs/_stake.ts
@@ -1,7 +1,9 @@
+import { promptConfirmationDialog } from "@commands/lib/_cmd-utils";
 import { CommandContext } from "@types-local/commands";
 import {
   ActionRowBuilder,
   ButtonBuilder,
+  ButtonInteraction,
   ButtonStyle,
   ComponentType,
   EmbedBuilder,
@@ -275,73 +277,56 @@ export async function confirmStake(
     });
 
   if (coinsValue > 0) {
-    const confirmEmbed = new EmbedBuilder()
-      .setColor("DarkRed")
-      .setDescription(
-        `Are you sure you want to stake ${p2} for ${Util.toKMB(
+    const handleConfirm = async (i: ButtonInteraction) => {
+      await sendStakeInvite(ctx, p1, p2, coinsValue);
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setColor("DarkRed")
+            .setDescription(`Stake request sent.`),
+        ],
+        components: [],
+      });
+    };
+
+    const handleCancel = async (i: ButtonInteraction) => {
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setColor("DarkRed")
+            .setDescription(`Stake request cancelled.`),
+        ],
+        components: [],
+      });
+    };
+
+    const handleExpiry = async () => {
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setColor("DarkRed")
+            .setDescription(`Stake expired.`),
+        ],
+        components: [],
+      });
+    };
+
+    await promptConfirmationDialog(
+      interaction,
+      {
+        handleConfirm,
+        handleCancel,
+        handleExpiry,
+      },
+      {
+        confirmButtonLabel: "Yes",
+        cancelButtonLabel: "No",
+        title: `Staking: ${p2.displayName}`,
+        prompt: `Are you sure you want to stake ${p2} for ${Util.toKMB(
           coinsValue
-        )} coins?`
-      );
-
-    const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId("yes")
-        .setLabel("Yes")
-        .setStyle(ButtonStyle.Success),
-      new ButtonBuilder()
-        .setCustomId("no")
-        .setLabel("No")
-        .setStyle(ButtonStyle.Danger)
-    );
-
-    const msg = await interaction.reply({
-      embeds: [confirmEmbed],
-      components: [actionRow],
-      flags: [MessageFlags.Ephemeral],
-      withResponse: true,
-    });
-
-    const collector = msg.resource?.message?.createMessageComponentCollector({
-      time: 30000,
-      componentType: ComponentType.Button,
-    });
-
-    collector?.on("collect", async (i) => {
-      if (i.customId === "no") {
-        await i.update({
-          embeds: [
-            new EmbedBuilder()
-              .setColor("DarkRed")
-              .setDescription(`Stake request cancelled.`),
-          ],
-          components: [],
-        });
-      } else if (i.customId === "yes") {
-        await sendStakeInvite(ctx, p1, p2, coinsValue);
-        await i.update({
-          embeds: [
-            new EmbedBuilder()
-              .setColor("DarkRed")
-              .setDescription(`Stake request sent.`),
-          ],
-          components: [],
-        });
+        )} coins?`,
       }
-
-      collector.stop();
-    });
-
-    collector?.on("end", async (_, reason) => {
-      if (reason === "time")
-        await interaction.editReply({
-          embeds: [
-            new EmbedBuilder()
-              .setColor("DarkRed")
-              .setDescription(`Stake expired.`),
-          ],
-          components: [],
-        });
-    });
+    );
   } else {
     await sendStakeInvite(ctx, p1, p2, 0);
     await interaction.reply({

--- a/src/commands/rs/_transfer.ts
+++ b/src/commands/rs/_transfer.ts
@@ -1,4 +1,4 @@
-import { promptConfirmationDialog } from "@commands/lib/_cmd-utils";
+import { promptConfirmationDialog } from "../lib/_cmd-utils.js";
 import { CommandContext } from "@types-local/commands";
 import {
   ButtonInteraction,

--- a/src/commands/rs/_transfer.ts
+++ b/src/commands/rs/_transfer.ts
@@ -1,11 +1,8 @@
+import { promptConfirmationDialog } from "@commands/lib/_cmd-utils";
 import { CommandContext } from "@types-local/commands";
 import {
-  ActionRowBuilder,
-  ButtonBuilder,
   ButtonInteraction,
-  ButtonStyle,
   CacheType,
-  ComponentType,
   EmbedBuilder,
   MessageFlags,
   User,
@@ -20,7 +17,6 @@ async function executeTransfer(
   i: ButtonInteraction<CacheType>
 ) {
   const { storage } = ctx;
-  const amountKmb = Util.toKMB(value);
   await storage.updateCoins(p1.id, value * -1);
   await storage.updateCoins(p2.id, value);
 
@@ -53,72 +49,52 @@ export async function transferCoins(
       flags: [MessageFlags.Ephemeral],
     });
   } else {
-    const msg = await interaction.reply({
-      embeds: [
-        new EmbedBuilder()
-          .setTitle(`Transfer to ${p2.displayName}`)
-          .setColor("DarkRed")
-          .setDescription(
-            `Are you sure you want to transfer ${value.toLocaleString()} coins to ${p2}?`
-          ),
-      ],
-      components: [
-        new ActionRowBuilder<ButtonBuilder>().setComponents(
-          new ButtonBuilder()
-            .setCustomId("yes")
-            .setLabel("Yes")
-            .setStyle(ButtonStyle.Success),
-          new ButtonBuilder()
-            .setCustomId("no")
-            .setLabel("No")
-            .setStyle(ButtonStyle.Danger)
-        ),
-      ],
-    });
+    const handleConfirm = async (i: ButtonInteraction) =>
+      await executeTransfer(ctx, p1, p2, value, i);
 
-    const collector = msg.createMessageComponentCollector({
-      filter: (i) => i.user.id === p1.id,
-      time: 15000,
-      componentType: ComponentType.Button,
-    });
+    const handleCancel = async (i: ButtonInteraction) =>
+      await i.update({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle(`Transfer to ${p2.displayName}`)
+            .setColor("DarkRed")
+            .setDescription(`Transfer cancelled.`),
+        ],
+        components: [],
+      });
 
-    collector.on("collect", async (i) => {
-      if (i.customId === "yes") {
-        await executeTransfer(ctx, p1, p2, value, i);
-      } else {
-        await i.update({
-          embeds: [
-            new EmbedBuilder()
-              .setTitle(`Transfer to ${p2.displayName}`)
-              .setColor("DarkRed")
-              .setDescription(`Transfer cancelled.`),
-          ],
-          components: [],
-        });
-      }
-
-      collector.stop();
-    });
-
-    collector.on("ignore", async (i) => {
+    const handleIgnore = async (i: ButtonInteraction) =>
       await i.reply({
         content: "Only the issuer of the transfer can confirm or rescind it.",
         flags: [MessageFlags.Ephemeral],
       });
-    });
 
-    collector.on("end", async (_, reason) => {
-      if (reason === "time") {
-        await interaction.editReply({
-          embeds: [
-            new EmbedBuilder()
-              .setTitle(`Transfer to ${p2.displayName}`)
-              .setColor("DarkRed")
-              .setDescription(`Transfer expired.`),
-          ],
-          components: [],
-        });
+    const handleExpiry = async () =>
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle(`Transfer to ${p2.displayName}`)
+            .setColor("DarkRed")
+            .setDescription(`Transfer expired.`),
+        ],
+        components: [],
+      });
+
+    await promptConfirmationDialog(
+      interaction,
+      {
+        handleConfirm,
+        handleCancel,
+        handleIgnore,
+        handleExpiry,
+      },
+      {
+        confirmButtonLabel: "Yes",
+        cancelButtonLabel: "No",
+        title: `Transfer to ${p2.displayName}`,
+        prompt: `Are you sure you want to transfer ${value.toLocaleString()} coins to ${p2}?`,
+        ephemeral: false,
       }
-    });
+    );
   }
 }


### PR DESCRIPTION
## Changes
### Dev
- Added a function for spawning customizable confirmation prompts to `src/commands/lib/cmd-utils.ts`.
- Parameters and types are as follows:
 

`interaction  (ChatInputCommandInteraction<CacheType>)` \
 The original interaction that prompted the confirmation dialog. Used to find author's user ID.

`handlers (ConfirmationDialogHandlers)` \
Functions that define the action to take upon catching each event. Has default values.
```ts
type ConfirmationDialogHandlers = { 
  handleConfirm?: (i: ButtonInteraction<CacheType>) => Promise<any>;
  handleCancel?: (i: ButtonInteraction<CacheType>) => Promise<any>;
  handleIgnore?: (i: ButtonInteraction<CacheType>) => Promise<any>;
  handleExpiry?: () => Promise<any>;
};
```

`opts (ConfirmationDialogOpts)` \
 Customizations on the confirmation dialog. Has default values.
```ts
type ConfirmationDialogOpts = {
  confirmButtonLabel?: string;
  cancelButtonLabel?: string;
  prompt?: string;
  title?: string;
  ephemeral?: boolean;
  expiryMs?: number;
};
```

