### PR TITLE
Clue cd

### DIFF
--- a/src/commands/rs.ts
+++ b/src/commands/rs.ts
@@ -22,7 +22,18 @@ const rsData = new SlashCommandBuilder()
       .setName("clue")
       .setDescription("Run clue-related commands.")
       .addSubcommand((opt) =>
-        opt.setName("open").setDescription("Open a random clue casket!")
+        opt
+          .setName("open")
+          .setDescription("Open a random clue casket!")
+          .addNumberOption((opt) =>
+            opt
+              .setName("number")
+              .setDescription(
+                "Number of clues to open. More than one may incur extra cooldown per clue."
+              )
+              .setMinValue(1)
+              .setRequired(false)
+          )
       )
       .addSubcommand((opt) =>
         opt.setName("stats").setDescription("View your clue stats.")

--- a/src/commands/rs/_clue.ts
+++ b/src/commands/rs/_clue.ts
@@ -16,10 +16,11 @@ async function checkCooldown(ctx: CommandContext): Promise<boolean> {
   const cd = await storage.checkCdByKey(interaction.user.id, "clues");
 
   if (cd > 0) {
+    const mins = Math.floor(cd / 60);
     await interaction.reply({
-      content: `You are currently on cooldown for clues!\nYou can try again in ${Math.floor(
-        cd
-      )} second(s).`,
+      content: `You are currently on cooldown for clues!\nYou can try again in ${
+        mins >= 1 ? `${mins} minute(s)` : `${cd} second(s).`
+      }`,
       flags: [MessageFlags.Ephemeral],
     });
 
@@ -31,14 +32,28 @@ async function checkCooldown(ctx: CommandContext): Promise<boolean> {
 
 export async function openClue(ctx: CommandContext) {
   const { interaction, storage } = ctx;
-
+  const numberToOpen = interaction.options.getNumber("number") ?? 1;
+  const cdSecsPerClue =
+    numberToOpen >= 10 ? 12 * 2 : numberToOpen > 1 ? 12 + 4.5 : 12;
+  const bulkLimit = Math.floor(3600 / cdSecsPerClue);
   if (await checkCooldown(ctx)) return;
+  if (numberToOpen > bulkLimit) {
+    return await interaction.reply({
+      content: `You may only open up to an hour's worth of clues at a time (${bulkLimit}).`,
+      flags: [MessageFlags.Ephemeral],
+    });
+  }
 
   const roll = Math.round(Math.random() * 3);
   const res = clueList[roll];
-  const rewards = res.tier.open(res.num).items();
+  const rewards = res.tier
+    .open(res.num * numberToOpen)
+    .items()
+    .sort((a, b) => b[0].price - a[0].price);
 
   const { got, total, totalRaw } = parseLoot(rewards);
+
+  const lines = got.split("\n").length;
 
   const toUpdate = getEmptyClueData();
   const clueType = res.name.toLowerCase() as
@@ -67,13 +82,29 @@ export async function openClue(ctx: CommandContext) {
           name: interaction.user.displayName,
           iconURL: interaction.user.displayAvatarURL() ?? "",
         })
-        .setTitle(`Clue scroll (${res.name.toLowerCase()})`)
-        .setDescription(`${got}`)
+        .setTitle(
+          `${
+            numberToOpen > 1 ? `${numberToOpen}x ` : ""
+          }Clue scroll (${res.name.toLowerCase()})`
+        )
+        .setDescription(
+          `${
+            numberToOpen <= 5
+              ? got
+              : `${got.split("\n").slice(0, 5).join("\n")}\n...and ${
+                  lines - 5
+                } more lines...`
+          }`
+        )
         .setFooter({ text: `Total loot: ${total}` }),
     ],
   });
 
-  await storage.setCdByKey(interaction.user.id, "clues", 12);
+  await storage.setCdByKey(
+    interaction.user.id,
+    "clues",
+    cdSecsPerClue * numberToOpen
+  );
   await storage.updateInventory(interaction.user.id, rewards);
 }
 

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -16,6 +16,9 @@ type RetrievedGatekept = {
   guildId: string;
   channelId: string;
 };
+
+export type RsCdStores = "clues";
+
 export abstract class Storage {
   abstract getInMemory(key: string): string | null;
   abstract setInMemory(key: string, value: string): void;
@@ -77,6 +80,14 @@ export abstract class Storage {
   ): Promise<void>;
 
   abstract checkKillCd(userId: string, monsterId: number): Promise<number>;
+
+  abstract setCdByKey(
+    userId: string,
+    cdKey: RsCdStores,
+    cdSecs: number
+  ): Promise<void>;
+
+  abstract checkCdByKey(userId: string, cdKey: RsCdStores): Promise<number>;
 
   abstract updateInventory(
     userId: string,


### PR DESCRIPTION
## Changes
### Features
- Each clue now incurs a 12-second cooldown when opened alone.
- When (1, 10) clues are opened at a time, an extra 4.5 seconds of cooldown is incurred.
- When [10, `x`) clues are opened at a time, the cooldown per clue is doubled.
  - `x` is the number of clues one can open per hour (3600 divided by the doubled cooldown).